### PR TITLE
Make sure `package*.json` are available during build (#42)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - .:/code:delegated
       # use the container's node_modules folder (don't override)
-      - /code/node_modules/
+      - /code/frontend/node_modules/
       - /code/static/
       - ${HOME}/mylasecrets:/secrets
     ports:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
 RUN pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /code/frontend
+COPY /frontend/package*.json /code/frontend/
 
 RUN npm install
 


### PR DESCRIPTION
This PR modifies the `Dockerfile` to ensure that the `package*.json` files are available during the build process (for `npm install`). In addition, it modifies the volume mapping in `docker-compose.yml` to correctly (?) prevent `node_modules` in the local repository from being copied into the container (see https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder; you may also be able to use `.dockerignore`, ignoring `node_modules`). The PR aims to resolve #42.