### PR TITLE
Switch project to using MySQL in dev instead of SQLLITE

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -76,8 +76,17 @@ WSGI_APPLICATION = 'backend.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': os.getenv('DB_NAME', 'canvas_app_explorer_local'),
+        'USER': os.getenv('DB_USER', 'cae_user'),
+        'PASSWORD': os.getenv('DB_PASSWORD', 'cae_pw'),
+        'HOST': os.getenv('DB_HOST', 'canvas_app_explorer_mysql'),
+        'PORT': os.getenv('DB_PORT', '3306'),
+        'OPTIONS': {'charset': 'utf8mb4'},
+        'TEST': {
+            'CHARSET': 'utf8mb4',
+            'COLLATION': 'utf8mb4_unicode_ci'
+        }
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   mysql:
     image: mysql:5.7
-    restart: on-failure
+    restart: unless-stopped
     command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     environment:
       - MYSQL_ROOT_PASSWORD=cae_root_pw
@@ -14,7 +14,7 @@ services:
       - MYSQL_USER=cae_user
       - MYSQL_PASSWORD=cae_pw
     ports:
-      - "5306:3306"
+      - "6306:3306"
     volumes:
       - ./.data/mysql:/var/lib/mysql:delegated
     container_name: canvas_app_explorer_mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,23 @@
 version: "3.9"
    
 services:
+
+  mysql:
+    image: mysql:5.7
+    restart: on-failure
+    command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
+    environment:
+      - MYSQL_ROOT_PASSWORD=cae_root_pw
+      - MYSQL_HOST=canvas_app_explorer_mysql
+      - MYSQL_PORT=3306
+      - MYSQL_DATABASE=canvas_app_explorer_local
+      - MYSQL_USER=cae_user
+      - MYSQL_PASSWORD=cae_pw
+    ports:
+      - "5306:3306"
+    volumes:
+      - ./.data/mysql:/var/lib/mysql:delegated
+    container_name: canvas_app_explorer_mysql
   web:
     build:
       context: .


### PR DESCRIPTION
This PR modifies modifies `docker-compose` and `backend/settings.py` to switch the project to using MySQL in dev instead of SQLLITE. It adds a `mysql` service to `docker-compose`, adds a configuration approach by adding a container environment using the `environment` block in `docker-compose`, and sets up the database connection in Django by adding a `mysql` database connection in `backend/settings.py`. This PR aims to resolve #41. 