### PR TITLE
Fixes #50 - Admin page isn't able to load static css files.

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -16,6 +16,9 @@ import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+PROJECT_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), ".."),
+)
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
@@ -33,6 +36,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'backend.canvas_app_explorer',
+    'django.contrib.staticfiles',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -109,11 +113,13 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/django_static/'
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'frontend'),
 )
+
+STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
 
 WEBPACK_LOADER = {
     'DEFAULT': {

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -23,12 +23,17 @@ from django.views import static
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),
-    # TODO: Switch this to collectstatic and put it in static
-    re_path(r'^%s(?P<path>.*)$' % settings.STATIC_URL[1:], 
-        view = static.serve, 
-        kwargs = {'document_root': 
-            os.path.join(settings.BASE_DIR, 'frontend/public/'), 
-            'show_indexes' : True
+]
+
+# TODO: This is to aid local development. Switch this to collectstatic and put it in static
+# This exposes the frontend/public/plasmic directory on a url in static
+if settings.DEBUG:
+    urlpatterns += [
+        re_path(r'^static/plasmic/(?P<path>.*)$', 
+            view = static.serve, 
+            kwargs = {
+                'document_root': os.path.join(settings.BASE_DIR, 'frontend/public/plasmic'), 
+                'show_indexes' : True
             }
         )
     ]


### PR DESCRIPTION
Move django static files to a different path (django_static) and only add the frontend in development mode.

This will need to change a bit as we move to production but I feel like I see what's going on here now.