### PR TITLE
Fixes #58 add iniital support for retrieving data via REST

### DIFF
--- a/backend/canvas_app_explorer/serializers.py
+++ b/backend/canvas_app_explorer/serializers.py
@@ -2,12 +2,14 @@ from canvas_app_explorer import models
 from rest_framework import serializers
 
 class CanvasPlacementSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = models.CanvasPlacement
         fields = '__all__'
 
 class LtiToolSerializer(serializers.ModelSerializer):
-    canvas_placement = CanvasPlacementSerializer(read_only=True, many=True)
+    # Addiitonal expanded ead only field to make it easier on the front-end
+    canvas_placement_expanded = CanvasPlacementSerializer(read_only=True, many=True, source="canvas_placement")
 
     class Meta:
         model = models.LtiTool

--- a/backend/canvas_app_explorer/serializers.py
+++ b/backend/canvas_app_explorer/serializers.py
@@ -1,0 +1,14 @@
+from canvas_app_explorer import models
+from rest_framework import serializers
+
+class CanvasPlacementSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.CanvasPlacement
+        fields = '__all__'
+
+class LtiToolSerializer(serializers.ModelSerializer):
+    canvas_placement = CanvasPlacementSerializer(read_only=True, many=True)
+
+    class Meta:
+        model = models.LtiTool
+        fields = '__all__'

--- a/backend/canvas_app_explorer/views.py
+++ b/backend/canvas_app_explorer/views.py
@@ -12,6 +12,4 @@ class LTIToolViewSet(viewsets.ModelViewSet):
     queryset = models.LtiTool.objects.all()
     serializer_class = serializers.LtiToolSerializer
 
-    # This may later change to DjangoModelPermissions, or IsAdminUser might be fine
-    # This allows ReadOnly to GET but only Admin can modify
-    permission_classes = [permissions.IsAdminUser, permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [permissions.DjangoModelPermissionsOrAnonReadOnly]

--- a/backend/canvas_app_explorer/views.py
+++ b/backend/canvas_app_explorer/views.py
@@ -1,3 +1,17 @@
 from django.shortcuts import render
 
-# Create your views here.
+from rest_framework import permissions, viewsets
+
+from canvas_app_explorer import models, serializers
+
+
+class LTIToolViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows users to be viewed or edited.
+    """
+    queryset = models.LtiTool.objects.all()
+    serializer_class = serializers.LtiToolSerializer
+
+    # This may later change to DjangoModelPermissions, or IsAdminUser might be fine
+    # This allows ReadOnly to GET but only Admin can modify
+    permission_classes = [permissions.IsAdminUser, permissions.IsAuthenticatedOrReadOnly]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'webpack_loader',
+    'rest_framework',
 ]
 
 MIDDLEWARE = [

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -15,12 +15,22 @@ Including another URLconf
 """
 import os
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
+
 from django.conf import settings
-from django.urls import path, re_path 
+from django.urls import include, path, re_path 
 from django.views.generic import TemplateView
 from django.views import static
+from rest_framework import routers
+from canvas_app_explorer import views
+
+router = routers.DefaultRouter()
+router.register(r'lti_tools', views.LTIToolViewSet)
 
 urlpatterns = [
+    path('', include(router.urls)),
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+
     path('admin/', admin.site.urls),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),
 ]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -28,8 +28,8 @@ router = routers.DefaultRouter()
 router.register(r'lti_tools', views.LTIToolViewSet)
 
 urlpatterns = [
-    path('', include(router.urls)),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('api/', include(router.urls)),
+    path('api/auth/', include('rest_framework.urls', namespace='rest_framework')),
 
     path('admin/', admin.site.urls),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 Django
 django-webpack-loader
 mysqlclient
+
+# DRF
+djangorestframework
+markdown       # Markdown support for the browsable API.
+django-filter  # Filtering support


### PR DESCRIPTION
The url's I'm adding here are at lti_tools. You can modify them with admin. Everything looks like it works except for the images which I opened a new issue to look at.

The format that the frontend will get will be something like

`[{"id":1,"canvas_placement":[{"id":1,"name":"Navigation"}],"name":"Zoom","logo_image":"","main_image":"","short_description":"Zoom short description","long_description":"Zoom Long Description","privacy_agreement":"None","support_resources":"None"}]`