### PR TITLE
Revert Previous Plasmic Changes

### DIFF
--- a/frontend/components/plasmic/canvas_app_explorer/PlasmicAddRemoveButton.css
+++ b/frontend/components/plasmic/canvas_app_explorer/PlasmicAddRemoveButton.css
@@ -10,3 +10,12 @@
   background: linear-gradient(#ff0000, #ff0000),
     linear-gradient(#2bc744, #2bc744), #015906;
 }
+.AddRemoveButton__root___2GPd2:active {
+  background: linear-gradient(#ff0000, #ff0000),
+    linear-gradient(#2bc744, #2bc744), #015906;
+}
+.AddRemoveButton__root__removeToolFromSite___2GPd2Vv3Fi:active {
+  background: linear-gradient(#2bc744, #2bc744),
+    linear-gradient(#ffffff, #ffffff), linear-gradient(#ff0000, #ff0000),
+    linear-gradient(#2bc744, #2bc744), #015906;
+}

--- a/frontend/components/plasmic/canvas_app_explorer/PlasmicAddRemoveButton.jsx
+++ b/frontend/components/plasmic/canvas_app_explorer/PlasmicAddRemoveButton.jsx
@@ -13,6 +13,7 @@ import {
   hasVariant,
   classNames,
   createPlasmicElementProxy,
+  useTrigger,
   deriveRenderOpts
 } from "@plasmicapp/react-web";
 import "@plasmicapp/react-web/lib/plasmic.css";
@@ -28,6 +29,11 @@ export const PlasmicAddRemoveButton__ArgProps = new Array();
 
 function PlasmicAddRemoveButton__RenderFunc(props) {
   const { variants, args, overrides, forNode, dataFetches } = props;
+  const [isRootActive, triggerRootActiveProps] = useTrigger("usePressed", {});
+  const triggers = {
+    active_root: isRootActive
+  };
+
   return (
     <div
       data-plasmic-name={"root"}
@@ -48,8 +54,14 @@ function PlasmicAddRemoveButton__RenderFunc(props) {
           )
         }
       )}
+      data-plasmic-trigger-props={[triggerRootActiveProps]}
     >
-      {hasVariant(variants, "removeToolFromSite", "removeToolFromSite")
+      {hasVariant(variants, "removeToolFromSite", "removeToolFromSite") &&
+      triggers.active_root
+        ? "Add Tool to Site"
+        : triggers.active_root
+        ? "Remove Tool "
+        : hasVariant(variants, "removeToolFromSite", "removeToolFromSite")
         ? "Remove Tool "
         : "Add Tool to Site"}
     </div>

--- a/frontend/components/plasmic/canvas_app_explorer/PlasmicHome.css
+++ b/frontend/components/plasmic/canvas_app_explorer/PlasmicHome.css
@@ -135,11 +135,6 @@
   padding: 0px 15px;
   background: #ffffff;
 }
-.Home__learnMoreButton__j6ASy.__wab_instance {
-  position: absolute;
-  top: 14px;
-  left: 21px;
-}
 .Home__myLaCard__gpGZx.__wab_instance {
   position: relative;
   left: auto;
@@ -168,11 +163,6 @@
 .Home__box__jl7El {
   padding: 0px 15px;
 }
-.Home__learnMoreButton__nlkni.__wab_instance {
-  position: absolute;
-  top: 14px;
-  left: 21px;
-}
 .Home__piazzaCard___71L95.__wab_instance {
   position: relative;
   left: auto;
@@ -200,11 +190,6 @@
 .Home__box__qBpZp {
   padding: 0px 15px;
 }
-.Home__learnMoreButton___2ItBp.__wab_instance {
-  position: absolute;
-  top: 14px;
-  left: 21px;
-}
 .Home__panoptoCard__cv5Of.__wab_instance {
   position: relative;
   flex-shrink: 0;
@@ -231,15 +216,10 @@
 .Home__ratings__iLj6H.__wab_instance {
   position: relative;
 }
-.Home__addRemoveButton__kxwUy.__wab_instance {
+.Home__addRemoveButton__j61Ew.__wab_instance {
   width: 120px;
   height: 30px;
   margin-right: 10px;
-}
-.Home__learnMoreButton__ewrFh.__wab_instance {
-  position: absolute;
-  top: 14px;
-  left: 21px;
 }
 .Home__footer__sUgvZ.__wab_instance {
   position: relative;

--- a/frontend/components/plasmic/canvas_app_explorer/PlasmicHome.jsx
+++ b/frontend/components/plasmic/canvas_app_explorer/PlasmicHome.jsx
@@ -133,14 +133,6 @@ function PlasmicHome__RenderFunc(props) {
               <ProductCard
                 data-plasmic-name={"zoomCard"}
                 data-plasmic-override={overrides.zoomCard}
-                addRemoveSlot={
-                  <AddRemoveButton
-                    className={classNames(
-                      "__wab_instance",
-                      "Home__addRemoveButton___3D93M"
-                    )}
-                  />
-                }
                 className={classNames(
                   "__wab_instance",
                   "Home__zoomCard__foQyr"
@@ -196,19 +188,18 @@ function PlasmicHome__RenderFunc(props) {
                   />
                 }
                 title={"Zoom"}
-              />
+              >
+                <AddRemoveButton
+                  className={classNames(
+                    "__wab_instance",
+                    "Home__addRemoveButton___3D93M"
+                  )}
+                />
+              </ProductCard>
 
               <ProductCard
                 data-plasmic-name={"myLaCard"}
                 data-plasmic-override={overrides.myLaCard}
-                addRemoveSlot={
-                  <AddRemoveButton
-                    className={classNames(
-                      "__wab_instance",
-                      "Home__addRemoveButton__bH9Sb"
-                    )}
-                  />
-                }
                 className={classNames(
                   "__wab_instance",
                   "Home__myLaCard__gpGZx"
@@ -268,20 +259,18 @@ function PlasmicHome__RenderFunc(props) {
                   ) : null
                 }
                 title={"My Learning Analytics"}
-              />
+              >
+                <AddRemoveButton
+                  className={classNames(
+                    "__wab_instance",
+                    "Home__addRemoveButton__bH9Sb"
+                  )}
+                />
+              </ProductCard>
 
               <ProductCard
                 data-plasmic-name={"piazzaCard"}
                 data-plasmic-override={overrides.piazzaCard}
-                addRemoveSlot={
-                  <AddRemoveButton
-                    className={classNames(
-                      "__wab_instance",
-                      "Home__addRemoveButton___6ByWv"
-                    )}
-                    removeToolFromSite={"removeToolFromSite"}
-                  />
-                }
                 className={classNames(
                   "__wab_instance",
                   "Home__piazzaCard___71L95"
@@ -339,7 +328,15 @@ function PlasmicHome__RenderFunc(props) {
                   />
                 }
                 title={"Piazza"}
-              />
+              >
+                <AddRemoveButton
+                  className={classNames(
+                    "__wab_instance",
+                    "Home__addRemoveButton___6ByWv"
+                  )}
+                  removeToolFromSite={"removeToolFromSite"}
+                />
+              </ProductCard>
 
               <ProductCard
                 data-plasmic-name={"panoptoCard"}

--- a/frontend/components/plasmic/canvas_app_explorer/PlasmicProductCard.css
+++ b/frontend/components/plasmic/canvas_app_explorer/PlasmicProductCard.css
@@ -198,10 +198,16 @@
 .ProductCard__linkButton__withoutScreenshot__cX8QGutYkz.__wab_instance {
   flex-shrink: 0;
 }
-.ProductCard__learnMoreButton___0AuCk.__wab_instance {
+.ProductCard__learnMoreButton__uLwn9.__wab_instance {
   position: absolute;
   top: 14px;
   left: 21px;
+}
+.ProductCard__svg__kxRR {
+  position: relative;
+  object-fit: cover;
+  width: 1em;
+  height: 1em;
 }
 .ProductCard__img__bTZld {
   position: relative;

--- a/frontend/components/plasmic/canvas_app_explorer/PlasmicProductCard.jsx
+++ b/frontend/components/plasmic/canvas_app_explorer/PlasmicProductCard.jsx
@@ -39,13 +39,12 @@ export const PlasmicProductCard__ArgProps = new Array(
   "ratings",
   "logo",
   "description",
-  "addRemoveSlot",
+  "children",
   "toolLearnMore",
   "descriptionLearnMore",
   "privacyAgreementLearnMore",
   "placementsInCanvasLearnMore",
-  "supportResourcesLearnMore",
-  "learnMoreSlot"
+  "supportResourcesLearnMore"
 );
 
 function PlasmicProductCard__RenderFunc(props) {
@@ -423,7 +422,7 @@ function PlasmicProductCard__RenderFunc(props) {
                 />
               ),
 
-              value: args.addRemoveSlot
+              value: args.children
             })}
           />
         ) : null}
@@ -437,18 +436,51 @@ function PlasmicProductCard__RenderFunc(props) {
                 hasVariant(variants, "withoutScreenshot", "withoutScreenshot")
             }
           )}
-          text={p.renderPlasmicSlot({
-            defaultContents: (
-              <LearnMoreButton
-                className={classNames(
-                  "__wab_instance",
-                  "ProductCard__learnMoreButton___0AuCk"
-                )}
-              />
-            ),
-
-            value: args.learnMoreSlot
-          })}
+          text={
+            <React.Fragment>
+              {(
+                hasVariant(variants, "learnMore", "learnMore") ? false : true
+              ) ? (
+                <LearnMoreButton
+                  data-plasmic-name={"learnMoreButton"}
+                  data-plasmic-override={overrides.learnMoreButton}
+                  className={classNames(
+                    "__wab_instance",
+                    "ProductCard__learnMoreButton__uLwn9",
+                    {
+                      ProductCard__learnMoreButton__learnMore__uLwn9OklBv:
+                        hasVariant(variants, "learnMore", "learnMore"),
+                      ProductCard__learnMoreButton__withReviews__uLwn9VvVo9:
+                        hasVariant(variants, "withReviews", "withReviews"),
+                      ProductCard__learnMoreButton__withoutScreenshot__uLwn9UtYkz:
+                        hasVariant(
+                          variants,
+                          "withoutScreenshot",
+                          "withoutScreenshot"
+                        )
+                    }
+                  )}
+                  learnMore={
+                    hasVariant(variants, "learnMore", "learnMore")
+                      ? "learnMore"
+                      : undefined
+                  }
+                />
+              ) : null}
+              {false ? (
+                <svg
+                  data-plasmic-name={"svg"}
+                  data-plasmic-override={overrides.svg}
+                  className={classNames(
+                    "plasmic_default__all",
+                    "plasmic_default__svg",
+                    "ProductCard__svg__kxRR"
+                  )}
+                  role={"img"}
+                />
+              ) : null}
+            </React.Fragment>
+          }
         />
       </div>
 
@@ -638,9 +670,18 @@ function PlasmicProductCard__RenderFunc(props) {
 }
 
 const PlasmicDescendants = {
-  root: ["root", "learnMoreTool", "screenshotBackground"],
+  root: [
+    "root",
+    "learnMoreTool",
+    "screenshotBackground",
+    "learnMoreButton",
+    "svg"
+  ],
+
   learnMoreTool: ["learnMoreTool"],
-  screenshotBackground: ["screenshotBackground"]
+  screenshotBackground: ["screenshotBackground"],
+  learnMoreButton: ["learnMoreButton"],
+  svg: ["svg"]
 };
 
 function makeNodeComponent(nodeName) {
@@ -676,6 +717,8 @@ export const PlasmicProductCard = Object.assign(
     // Helper components rendering sub-elements
     learnMoreTool: makeNodeComponent("learnMoreTool"),
     screenshotBackground: makeNodeComponent("screenshotBackground"),
+    learnMoreButton: makeNodeComponent("learnMoreButton"),
+    svg: makeNodeComponent("svg"),
     // Metadata about props expected for PlasmicProductCard
     internalVariantProps: PlasmicProductCard__VariantProps,
     internalArgProps: PlasmicProductCard__ArgProps

--- a/frontend/plasmic.lock
+++ b/frontend/plasmic.lock
@@ -29,12 +29,12 @@
         {
           "type": "renderModule",
           "assetId": "4XPgsAhljqdds",
-          "checksum": "c4adac5069b085b8b708c4f599777dbb"
+          "checksum": "c9eb42b7c26ffc5909701f98eb67eb47"
         },
         {
           "type": "cssRules",
           "assetId": "4XPgsAhljqdds",
-          "checksum": "c4adac5069b085b8b708c4f599777dbb"
+          "checksum": "c9eb42b7c26ffc5909701f98eb67eb47"
         },
         {
           "type": "renderModule",
@@ -59,12 +59,12 @@
         {
           "type": "renderModule",
           "assetId": "zc_-JZqmkLhAk",
-          "checksum": "9657330786339cf628229e04f5a1c7cd"
+          "checksum": "c0064b8eb6695148b3bfb9079a2142fe"
         },
         {
           "type": "cssRules",
           "assetId": "zc_-JZqmkLhAk",
-          "checksum": "9657330786339cf628229e04f5a1c7cd"
+          "checksum": "c0064b8eb6695148b3bfb9079a2142fe"
         },
         {
           "type": "renderModule",
@@ -109,12 +109,12 @@
         {
           "type": "renderModule",
           "assetId": "JyIyDBiGW-",
-          "checksum": "b597c991ec7127c3ee70abc9626f8296"
+          "checksum": "123a9c363e950eb2ba69f5092113a43d"
         },
         {
           "type": "cssRules",
           "assetId": "JyIyDBiGW-",
-          "checksum": "b597c991ec7127c3ee70abc9626f8296"
+          "checksum": "123a9c363e950eb2ba69f5092113a43d"
         },
         {
           "type": "renderModule",


### PR DESCRIPTION
The new Plasmic changes that were added made the dynamic cards not render properly, so this PR switches the Plasmic code to the previous version that still had dynamic cards rendering properly. This version of the Plasmic design had the search tool and settings removed from the UI until they are implemented, but before any other changes were made.