### PR TITLE
Fixes #91 - Create separate dockerfile to be used with openshift

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@
 # python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
 # DJANGO_SECRET_KEY=<some secret key, randomized by default>
 
+##### Optional configuration for defining hosts
 # Need to define this if using ngrok or other hosts
 ALLOWED_HOSTS=.ngrok.io,.localhost,127.0.0.1
 
@@ -47,11 +48,11 @@ ALLOWED_HOSTS=.ngrok.io,.localhost,127.0.0.1
 # For local debugging, not yet implemented. Sets Gunicorn to reload with 1 worker
 # DEBUGPY_ENABLE=true
 
-# Django log level
-# DJANGO_LOG_LEVEL=INFO
-
 # Currently needed for localhost, probably will just combine with DEBUGPY_ENABLE
 # DEBUG=True
+
+# Django log level
+# DJANGO_LOG_LEVEL=INFO
 
 # Root Log Level
 # ROOT_LOG_LEVEL=INFO

--- a/.env.sample
+++ b/.env.sample
@@ -10,7 +10,7 @@
 ALLOWED_HOSTS=.ngrok.io,.localhost,127.0.0.1
 
 # This is needed for Webpack if youŕe using NGrok and it has to be the URL to the frontend (which is what's running on port 3000)
-# You can leave this undefined if you're not using ngrok and it will default to http://localhost:3000/dist/
+# You can leave this undefined if you're not using ngrok and it will default to the value in docker-compose.yml or /static/bundles/
 # PUBLIC_PATH=https://1234567abcdef.ngrok.io/dist/
 
 ##### Database configuration values

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## Usage
 
+### Development mode
+
+Development mode for this application starts up 2 servers in the same container, one running on port 5000 (Python/Django backend) and one running on port 3000 (Node/React frontend). This allows for changes to be picked up and re-built from the mounted local volumes.
+
 With Docker installed run
 `docker-compose down; docker-compose build && docker-compose up`
 
@@ -12,3 +16,18 @@ To create a local admin user you should run this.
 ```
 docker exec -it canvas_app_explorer ./manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('admin', 'admin@example.com', 'admin')"
 ```
+
+Please see the Wiki for instructions on configuring with LTI
+
+### Testing production (Openshift) build
+
+The openshift build compiles all of the frontend assets into the container during the build. It uses whitenoise currently to serve up the content.
+
+To build, use the separate docker-compose-openshift-test.yml file. This uses a slightly different dockerfiles/Dockerfile.openshift that uses a static path and disables DEBUG.
+
+`docker compose -f docker-compose-openshift-test.yml build`
+
+Then to start it you can run
+`docker compose -f docker-compose-openshift-test.yml up`
+
+This should start up as expected on http://localhost:5000

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -30,7 +30,7 @@ PROJECT_ROOT = os.path.abspath(
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', get_random_secret_key())
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True if os.getenv("DEBUG") == "True" else False
+DEBUG = os.getenv("DEBUG", 'false').lower() in ('true', '1', 't')
 
 ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')
 
@@ -118,7 +118,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
-STATIC_URL = '/django_static/'
+STATIC_URL = '/static/'
 
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'frontend'),

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -41,8 +41,9 @@ urlpatterns = [
     path('',include(canvas_app_explorer_urls))
 ]
 
-# TODO: This is to aid local development. Switch this to collectstatic and put it in static
-# This exposes the frontend/public/plasmic directory on a url in static
+# This is to aid local development. 
+# This exposes the frontend/public/plasmic directory on a url in static and allows browsing.
+# Whitenoise currently handles this otherwise
 if settings.DEBUG:
     from django.contrib.staticfiles import views as static_views
 

--- a/docker-compose-openshift-test.yml
+++ b/docker-compose-openshift-test.yml
@@ -21,20 +21,16 @@ services:
   web:
     build:
       context: .
-      dockerfile: dockerfiles/Dockerfile
+      dockerfile: dockerfiles/Dockerfile.openshift
       args:
         TZ: ${TZ}
     volumes:
-      - .:/code:delegated
-      # use the container's node_modules folder (don't override)
-      - /code/frontend/node_modules/
-      - /code/static/
+      # Only map the secrets for prod build
       - ${HOME}/mylasecrets:/secrets
     ports:
       - "5000:5000"
-      - "3000:3000"
-    container_name: canvas_app_explorer
+    container_name: canvas_app_explorer_prod
     env_file:
-      - .env
+      - .env.openshift
     environment:
-      - DEBUG=True
+      - DEBUG=False

--- a/docker-compose-openshift-test.yml
+++ b/docker-compose-openshift-test.yml
@@ -22,8 +22,10 @@ services:
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.openshift
+      # This path has to be passed during the build here
       args:
-        TZ: ${TZ}
+        - TZ=${TZ}
+        - PUBLIC_PATH=/static/bundles/
     volumes:
       # Only map the secrets for prod build
       - ${HOME}/mylasecrets:/secrets
@@ -31,6 +33,6 @@ services:
       - "5000:5000"
     container_name: canvas_app_explorer_prod
     env_file:
-      - .env.openshift
+      - .env
     environment:
       - DEBUG=False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,4 @@ services:
       - .env
     environment:
       - DEBUG=True
+      - PUBLIC_PATH=http://localhost:3000/dist/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   web:
     build:
       context: .
-      dockerfile: dockerfiles/Dockerfile
+      dockerfile: dockerfiles/Dockerfile.openshift
       args:
         TZ: ${TZ}
     volumes:
@@ -36,6 +36,5 @@ services:
     container_name: canvas_app_explorer
     env_file:
       - .env
-          # Needed for the localhost views
     environment:
       - DEBUG=True

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -36,6 +36,10 @@ COPY . .
 
 # Build the frontend with webpack
 WORKDIR /code/frontend
+
+ARG PUBLIC_PATH
+ENV PUBLIC_PATH ${PUBLIC_PATH:-/static/bundles/}
+
 RUN ./node_modules/.bin/webpack --config webpack.config.js 
 
 # Collect the static files in the backend

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -1,0 +1,54 @@
+# FROM directive instructing base image to build upon
+# This could be used as a base instead: 
+# https://hub.docker.com/r/nikolaik/python-nodejs
+FROM python:3.8-slim AS app
+
+# NOTE: requirements.txt not likely to change between dev builds
+COPY requirements.txt .
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential default-libmysqlclient-dev netcat vim-tiny jq python3-dev git supervisor curl && \
+    apt-get upgrade -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+WORKDIR /code/frontend
+
+ENV NODE_VERSION=14.17.4
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION} && \
+    . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION} && \
+    . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version && npm --version
+
+COPY /frontend/package*.json /code/frontend/
+
+RUN npm install
+
+WORKDIR /code
+
+# NOTE: project files likely to change between dev builds
+COPY . .
+
+# Build the frontend with webpack
+WORKDIR /code/frontend
+RUN ./node_modules/.bin/webpack --config webpack.config.js 
+
+# Collect the static files in the backend
+WORKDIR /code
+RUN python manage.py collectstatic --verbosity 0
+
+# Sets the locl timezone of the docker image
+ARG TZ
+ENV TZ ${TZ:-America/Detroit}
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# EXPOSE port 5000 to allow communication to/from server
+EXPOSE 5000
+
+CMD ["/code/start_backend.sh"]
+# done!

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -2,8 +2,8 @@ var path = require("path");
 var BundleTracker = require('webpack-bundle-tracker');
 var MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-// Try the environment variable, otherwise use default on localhost
-const PUBLIC_PATH = process.env.PUBLIC_PATH || 'http://localhost:3000/dist/';
+// Try the environment variable
+const PUBLIC_PATH = process.env.PUBLIC_PATH || '/static/bundles/';
 
 module.exports = {
   context: __dirname,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,6 @@ django-filter  # Filtering support
 
 #LTI 
 PyLTI1p3==1.9.1
+
+# For serving static files
+whitenoise==5.3.0

--- a/start_backend.sh
+++ b/start_backend.sh
@@ -25,6 +25,12 @@ if [ -z "${DB_PORT}" ]; then
     DB_PORT=3306
 fi
 
+# To have a more static default secret key, this should still be defined
+if [ -z "${DJANGO_SECRET_KEY}" ]; then
+    export DJANGO_SECRET_KEY=`python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
+    echo "DJANGO_SECRET_KEY not set, using random value"
+fi
+
 if [ "${GUNICORN_RELOAD}" ]; then
     GUNICORN_RELOAD="--reload"
 else


### PR DESCRIPTION
This is still a work in progress, working to get a separate docker file setup for Openshift testing where everything is compiled and running in Guincorn. Will probably need a separate docker-compose. 

- [x] Create separate Dockerfile to test Openshift config
- [x] Document how to use docker compose to test
- [x] Customize startup scripts to start in development mode