### PR TITLE
Removing as app as it's causing issues with openshift

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 # FROM directive instructing base image to build upon
 # This could be used as a base instead: 
 # https://hub.docker.com/r/nikolaik/python-nodejs
-FROM python:3.8-slim AS app
+FROM python:3.8-slim
 
 # NOTE: requirements.txt not likely to change between dev builds
 COPY requirements.txt .

--- a/dockerfiles/Dockerfile.openshift
+++ b/dockerfiles/Dockerfile.openshift
@@ -1,7 +1,7 @@
 # FROM directive instructing base image to build upon
 # This could be used as a base instead: 
 # https://hub.docker.com/r/nikolaik/python-nodejs
-FROM python:3.8-slim AS app
+FROM python:3.8-slim
 
 # NOTE: requirements.txt not likely to change between dev builds
 COPY requirements.txt .


### PR DESCRIPTION
No issue, but this is simple. 

Openshift is giving an error with "as app" in here so just remove it. Works fine either way here locally.