### PR TITLE
Make `DataElement` header smaller, bold (#222)

### DIFF
--- a/frontend/app/components/DataElement.tsx
+++ b/frontend/app/components/DataElement.tsx
@@ -17,7 +17,9 @@ export default function DataElement (props: DataElementProps) {
 
   return (
     <Container>
-      <Typography variant='h6' component='h3' gutterBottom>{name}</Typography>
+      <Typography variant='subtitle1' component='h3' gutterBottom>
+        <strong>{name}</strong>
+      </Typography>
       <Typography variant='body2'>{children}</Typography>
     </Container>
   );


### PR DESCRIPTION
The PR aims to resolve #222.


<img width="350" alt="Screen Shot 2022-06-23 at 4 44 19 PM" src="https://user-images.githubusercontent.com/35741256/175396442-ba2a493a-a160-48a7-8877-d5cfcadb6b3a.png">

