### PR TITLE
Fixes #220 Replace X_FRAME_OPTIONS with CSP

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,9 @@
 # The URL for an external help resource; defaults to an empty string
 # HELP_URL=https://github.com/tl-its-umich-edu/canvas-app-explorer
 
+# A comma separated list of domains to allow to be framed
+# CSP_FRAME_ANCESTORS=umich.instructure.com
+
 ##### Optional configuration for defining hosts
 # Need to define this if using ngrok or other hosts
 ALLOWED_HOSTS=.ngrok.io,.localhost,127.0.0.1

--- a/.env.sample
+++ b/.env.sample
@@ -18,7 +18,7 @@
 # The URL for an external help resource; defaults to an empty string
 # HELP_URL=https://github.com/tl-its-umich-edu/canvas-app-explorer
 
-# A comma separated list of domains to allow to be framed
+# A comma separated list of domains where you want to allow the application to be framed
 # CSP_FRAME_ANCESTORS=umich.instructure.com
 
 ##### Optional configuration for defining hosts

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -234,7 +234,7 @@ if CSRF_COOKIE_SECURE:
     # Enables Proxies that set headers
     USE_X_FORWARDED_HOST = os.getenv('USE_X_FORWARDED_HOST', True)
 
-# Set CSP_FRAME_SRC to the yours Canvas domains
+# Set CSP_FRAME_SRC to the your Canvas domains
 CSP_FRAME_ANCESTORS = ["'self'",] + os.getenv('CSP_FRAME_ANCESTORS', '').split(',')
 # Allow inline scripts and Google assets. I don't think these need to be configurable
 CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'", "www.google-analytics.com"]

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -236,11 +236,12 @@ if CSRF_COOKIE_SECURE:
 
 # Set CSP_FRAME_SRC to the your Canvas domains
 CSP_FRAME_ANCESTORS = ["'self'",] + os.getenv('CSP_FRAME_ANCESTORS', '').split(',')
-# Allow inline scripts and Google assets. I don't think these need to be configurable
-CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+# This is currently unsafe-inline because of PyLTI scripts. This may be fixed in the future.
+CSP_SCRIPT_SRC = ["'self'", "https:", "'unsafe-inline'"]
 CSP_IMG_SRC = ["'self'", "data:"]
 CSP_FONT_SRC = ["'self'"]
-CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
+# Allow inline styles. There are a few styles that come up in the report so it seems easier to just allow unsafe-inline here.
+CSP_STYLE_SRC = ["'self'", "https:", "'unsafe-inline'"]
 
 SESSION_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", 'None')
 CSRF_COOKIE_SAMESITE = os.getenv("CSRF_COOKIE_SAMESITE", 'None')

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -237,9 +237,9 @@ if CSRF_COOKIE_SECURE:
 # Set CSP_FRAME_SRC to the your Canvas domains
 CSP_FRAME_ANCESTORS = ["'self'",] + os.getenv('CSP_FRAME_ANCESTORS', '').split(',')
 # Allow inline scripts and Google assets. I don't think these need to be configurable
-CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'", "www.google-analytics.com"]
-CSP_IMG_SRC = ["'self'", "data:", "www.google-analytics.com"]
-CSP_FONT_SRC = ["'self'", "fonts.gstatic.com"]
+CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+CSP_IMG_SRC = ["'self'", "data:"]
+CSP_FONT_SRC = ["'self'"]
 CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
 
 SESSION_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", 'None')

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'canvas_oauth.middleware.OAuthMiddleware',
+    'csp.middleware.CSPMiddleware'
 ]
 
 ROOT_URLCONF = 'backend.urls'
@@ -86,7 +87,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'backend.wsgi.application'
-
 
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
@@ -147,8 +147,6 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 DEFAULT_FILE_STORAGE = 'backend.canvas_app_explorer.storage_get_file.DatabaseFileStorage'
 
-# TODO: Switch this to CSP for additional security
-X_FRAME_OPTIONS = 'ALLOWALL'
 
 # So request works over the proxy
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -235,6 +233,14 @@ if CSRF_COOKIE_SECURE:
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     # Enables Proxies that set headers
     USE_X_FORWARDED_HOST = os.getenv('USE_X_FORWARDED_HOST', True)
+
+# Set CSP_FRAME_SRC to the yours Canvas domains
+CSP_FRAME_ANCESTORS = ["'self'",] + os.getenv('CSP_FRAME_ANCESTORS', '').split(',')
+# Allow inline scripts and Google assets. I don't think these need to be configurable
+CSP_SCRIPT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'", "www.google-analytics.com"]
+CSP_IMG_SRC = ["'self'", "data:", "www.google-analytics.com"]
+CSP_FONT_SRC = ["'self'", "fonts.gstatic.com"]
+CSP_STYLE_SRC = ["'self'", "'unsafe-inline'"]
 
 SESSION_COOKIE_SAMESITE = os.getenv("SESSION_COOKIE_SAMESITE", 'None')
 CSRF_COOKIE_SAMESITE = os.getenv("CSRF_COOKIE_SAMESITE", 'None')

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-mysql
 django-db-file-storage # Support for storage in the database
 Pillow # Needed for images
 django-tinymce # Rich text editor
-django-csp #For Content Security Policy
+django-csp # For Content Security Policy
 
 # DRF
 djangorestframework

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-mysql
 django-db-file-storage # Support for storage in the database
 Pillow # Needed for images
 django-tinymce # Rich text editor
+django-csp #For Content Security Policy
 
 # DRF
 djangorestframework


### PR DESCRIPTION
I was looking to make this config a little simpler based on what you had in CCM and only configure what is really necessary which is the FRAME_ANCESTORS. I could make the others configurable with this as a default but it's a little messier using environment variables over JSON for configuration.

To test this you'd want to be browsing with the console window open to see if there's any CSP errors reported. All I saw are errors from Canvas about Sentry and some warnings about future versions of TinyMCE which are part of the plugin.

Perhaps we could get rid of some of the unsafe-inline, but would need to do a little more work, especially on scripts. And it might not be entirely possible? 

I also have some Google things in here that we're not using yet, but I'm sure we'll be adding Google Analytics to this to get some idea of usage. 