### PR TITLE
Configuring to ignore non LTS versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     ignore:
       - dependency-name: "django"
         versions:
-          - ">= 4.3"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
+          - "> 4.2"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/frontend"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "direct"
+    ignore:
+      - dependency-name: "django"
+        versions:
+          - ">= 4.3"  # This ignores versions above 4.2, allowing only 4.2.x LTS upgrades
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/frontend"


### PR DESCRIPTION
5.2 LTS isn't released until later in 2025 so going to see if it keeps it back to 4.2 releases