### PR TITLE
#320 upgrading to python 3.10 and Canvas Oauth pkg

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-   
 services:
   mysql:
     image: mysql:8-oracle

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,7 +1,7 @@
 # FROM directive instructing base image to build upon
 # This could be used as a base instead: 
 # https://hub.docker.com/r/nikolaik/python-nodejs
-FROM python:3.8-slim
+FROM python:3.10-slim-bookworm
 
 # NOTE: requirements.txt not likely to change between dev builds
 COPY requirements.txt .

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ PyLTI1p3==1.12.1
 canvasapi==3.3.0
 
 # Not in pypi https://github.com/Harvard-University-iCommons/django-canvas-oauth
-https://github.com/Harvard-University-iCommons/django-canvas-oauth/archive/v1.1.0.tar.gz
+https://github.com/Harvard-University-iCommons/django-canvas-oauth/archive/v1.1.1.tar.gz


### PR DESCRIPTION
Fixes #320 

I am using the same Python 3.10 version that Myla is using.

I was able to build, start and launch the tool 