### PR TITLE
#372 remove Mysql Cache

### DIFF
--- a/backend/canvas_app_explorer/migrations/0013_drop_mysql_cache.py
+++ b/backend/canvas_app_explorer/migrations/0013_drop_mysql_cache.py
@@ -1,0 +1,24 @@
+
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('canvas_app_explorer', '0012_alter_ltitool_internal_notes'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS `canvas_app_explorer_cache`;",
+            reverse_sql="""
+            CREATE TABLE `canvas_app_explorer_cache` (
+                cache_key varchar(255) CHARACTER SET utf8 COLLATE utf8_bin
+                                       NOT NULL PRIMARY KEY,
+                value longblob NOT NULL,
+                value_type char(1) CHARACTER SET latin1 COLLATE latin1_bin
+                                   NOT NULL DEFAULT 'p',
+                expires BIGINT UNSIGNED NOT NULL
+            );
+            """
+        ),
+    ]


### PR DESCRIPTION
I created this migration file manually since there is no Model reference associated with it. I did not see any command that support to removal from Django-mysql Docs for using the management command `mysql_cache_migration`

https://django-mysql.readthedocs.io/en/latest/cache.html

The migration was applied and the table was deleted 