### PR TITLE
issue 444 use tool id instad of canvas_id

### DIFF
--- a/backend/canvas_app_explorer/serializers.py
+++ b/backend/canvas_app_explorer/serializers.py
@@ -33,7 +33,7 @@ class LtiToolSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.LtiTool
         fields = [
-            'name', 'canvas_id', 'logo_image', 'logo_image_alt_text', 'main_image',
+            'id', 'name', 'canvas_id', 'logo_image', 'logo_image_alt_text', 'main_image',
             'main_image_alt_text', 'short_description', 'long_description', 'privacy_agreement',
             'support_resources', 'canvas_placement_expanded', 'launch_url',
         ]

--- a/frontend/app/components/Home.tsx
+++ b/frontend/app/components/Home.tsx
@@ -47,7 +47,7 @@ function Home (props: HomeProps) {
     */
     setTools((oldTools) => {
       if (oldTools === undefined) throw Error('Expected tools variable to be defined!');
-      const newTools = oldTools.map(t => t.canvas_id === newTool.canvas_id ? newTool : t);
+      const newTools = oldTools.map(t => t.id === newTool.id ? newTool : t);
       return newTools;
     });
 


### PR DESCRIPTION
Those external link tools does not have canvas_id associated (null), because there are not Canvas LTI tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Tools now update reliably in lists and no longer duplicate due to inconsistent identifiers.
  - Improved rendering stability by using a consistent ID for each tool.

- Refactor
  - Standardized the tool identifier across the app for consistency.

- New Features
  - Tool data now includes a visible, stable ID in responses, enabling clearer identification and smoother updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->