### PR TITLE
#487 support asgi protocol

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -11,6 +11,10 @@ import os
 
 from django.core.asgi import get_asgi_application
 
+from backend.debugpy import check_and_enable_debugpy
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
+
+check_and_enable_debugpy()
 
 application = get_asgi_application()

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -60,7 +60,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
+    'servestatic.middleware.ServeStaticMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -11,10 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from backend.debugpy import check_and_enable_debugpy
-
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
-
-check_and_enable_debugpy()
 
 application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 gunicorn==23.0.0
+uvicorn-worker==0.4.0
 mysqlclient==2.2.7
 
 # Django and related
@@ -11,7 +12,7 @@ django-tinymce==4.1.0 # Rich text editor
 django-watchman==1.3
 django-webpack-loader==3.2.1
 Pillow==11.3.0
-whitenoise==6.9.0 # For serving static files
+servestatic==3.1.0 # For serving static files
 
 
 # DRF


### PR DESCRIPTION
Fixes #487 

Test plan written in the issue, Local uses pure Uvicorn and Prod use a mix of Guincorn + Uvicorn worker. This design is something followed for CCM, ROHQ.

