### PR TITLE
Fix the Docker build failure due to mariaDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,15 +22,11 @@ RUN apt-get update && \
     git \
     supervisor \
     curl \
-    pkg-config && \
+    pkg-config \
+    libmariadb-dev && \
     apt-get upgrade -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
-
-# Install MariaDB from the mariadb repository rather than using Debians 
-# https://mariadb.com/kb/en/mariadb-package-repository-setup-and-usage/
-RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash && \
-apt install -y --no-install-recommends libmariadb-dev
 
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
I saw this error when building the docker and the changes made to the PR fixes it. 

```
=> ERROR [stage-1  4/16] RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash && apt install -y --no-install-recommends libmariadb-dev                               1.7s
------
 > [stage-1  4/16] RUN curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash && apt install -y --no-install-recommends libmariadb-dev:
1.064 # [info] Checking for script prerequisites.
1.680 # [error] MariaDB Server version 12.rolling is not working.
1.680 #         Please verify that the version is correct.
1.680 #         Not all releases of MariaDB are available on all distributions.
1.680 #
1.680 #         The latest MariaDB Server versions are:
1.680 #             10.6.24 10.11.15 11.4.9 11.8.5
```