### PR TITLE
Import only what is needed - Tree shaking

### DIFF
--- a/frontend/app/components/AltTextHome.tsx
+++ b/frontend/app/components/AltTextHome.tsx
@@ -2,7 +2,7 @@ import { Box, Button } from '@mui/material';
 import React, { useState } from 'react';
 import { updateAltTextStartSync } from '../api';
 import ErrorsDisplay from './ErrorsDisplay';
-import { ArrowBack } from '@mui/icons-material';
+import ArrowBack from '@mui/icons-material/ArrowBack';
 import { Link } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import { Globals, SyncTask } from '../interfaces';


### PR DESCRIPTION
This change improves the JS bundle size and fixes the immediate issue with size problem

```
instructor_tools        | asset main-dc831b456875e207a598.js 11.3 MiB [emitted] [immutable] (name: main)
instructor_tools        | asset main-dc831b456875e207a598.css 1.39 KiB [emitted] [immutable] (name: main)
instructor_tools        | Entrypoint main 11.3 MiB = main-dc831b456875e207a598.css 1.39 KiB main-dc831b456875e207a598.js 11.3 MiB
```

We can think about this webpack Optimization #504 later as well