### PR TITLE
#539 removing the course id from FE api request

### DIFF
--- a/backend/canvas_app_explorer/alt_text_helper/urls.py
+++ b/backend/canvas_app_explorer/alt_text_helper/urls.py
@@ -3,7 +3,7 @@ from . import views
 
 urlpatterns = [
     path(
-        'scan/<int:course_id>',
+        'scan',
         views.AltTextScanViewSet.as_view({
             'post': 'start_scan',
             'get':'get_last_scan'}),

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -88,9 +88,8 @@ interface AltTextScanRequest {
   courseId: number
 }
 
-async function updateAltTextStartScan(data: AltTextScanRequest): Promise<AltTextScan> {
-  const { courseId } = data;
-  const url = `${API_BASE}/alt-text/scan/${courseId}`;
+async function updateAltTextStartScan(): Promise<AltTextScan> {
+  const url = `${API_BASE}/alt-text/scan`;
   const requestInit: RequestInit = {
     method: 'POST',
     headers: {
@@ -113,7 +112,7 @@ interface AltTextLastScanResponse {
 }
 async function getAltTextLastScan(data: AltTextScanRequest): Promise<AltTextLastScanDetail | false> {
   const { courseId } = data;
-  const url = `${API_BASE}/alt-text/scan/${courseId}`;
+  const url = `${API_BASE}/alt-text/scan`;
   const res = await fetch(url);
   if (!res.ok) {
     console.error(res);

--- a/frontend/app/components/AltTextHome.tsx
+++ b/frontend/app/components/AltTextHome.tsx
@@ -53,8 +53,8 @@ function AltTextHome (props: AltTextHomeProps) {
 
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
-    mutationFn: async (courseId : number) => {
-      return await updateAltTextStartScan({ courseId });
+    mutationFn: async () => {
+      return await updateAltTextStartScan();
     },
     onSuccess: (data) => {
       if (data.status == 'running' || data.status=='pending') {
@@ -65,7 +65,7 @@ function AltTextHome (props: AltTextHomeProps) {
   });
 
   const handleStartScan = async () => {
-    await mutate(course_id);
+    await mutate();
   };
 
   const handleStartReview = (category: ContentCategoryForReview ) => {


### PR DESCRIPTION
Fixes #539 

The Course scan should pull the course id from the request session as it is stored as part from the LTI launch.

Testing:
Make sure the course scan works from multiple courses. 