### PR TITLE
Switching mariadb and node to use the packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,10 +79,10 @@ COPY --from=node-build /build/node_modules ./frontend/node_modules
 
 # Sets the local timezone of the docker image
 ARG TZ
-ENV TZ ${TZ:-America/Detroit}
+ENV TZ=${TZ:-America/Detroit}
 # By default run a build that won't have a running frontend process (only used in dev)
 ARG RUN_FRONTEND
-ENV RUN_FRONTEND ${RUN_FRONTEND:-false} 
+ENV RUN_FRONTEND=${RUN_FRONTEND:-false} 
 
 # Run collectstatic *only* if RUN_FRONTEND is not true
 RUN if [ "$RUN_FRONTEND" != "true" ]; then \


### PR DESCRIPTION
(From Copilot)
This PR replaces the automated setup scripts for MariaDB and Node.js with manual package repository configuration to avoid potential Cloudflare issues and improve stability.

Changes:

- Removed dependency on third-party setup scripts for MariaDB and Node.js installation
- Implemented explicit APT repository configuration with GPG key management
- Hardcoded the Debian version (bookworm) for MariaDB repository stability