### PR TITLE
Adding initial copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,7 +74,7 @@ docker-compose build
 docker-compose up
 
 # Access: http://localhost:5000/ (requires LTI launch from Canvas)
-# Swagger API docs: Right-click iframe → View Frame Source → change URL to /api/schema/swagger-ui
+# Swagger API docs: http://localhost:5000/api/schema/swagger-ui  (or append /api/schema/swagger-ui to your Canvas launch URL)
 ```
 
 ### IMPORTANT: All Commands Run in Docker


### PR DESCRIPTION
To give additional context for GH copilot. This isn't needed for the release but has been a lot more helpful working with the Copilot AI to not have to keep repeating myself. 

Copilot is pretty good at keeping this updated, but it's pretty straightforward and looked like it included a lot of nice basics to me. 

Fixes #589