### PR TITLE
#629 remove the paste plugin

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -242,7 +242,7 @@ DRF_TRACKING_LOGGING = {
 
 TINYMCE_DEFAULT_CONFIG = {
     'menubar': True,
-    "plugins": "advlist,autolink,code,lists,link,anchor,insertdatetime,media,table,paste,wordcount",
+    "plugins": "advlist,autolink,code,lists,link,anchor,insertdatetime,media,table,wordcount",
     "toolbar": "bold italic backcolor | "
         "bullist numlist outdent indent | removeformat | code | help",
     "default_link_target": "_blank",


### PR DESCRIPTION
Fixes #629 

I don't feel the `paste` plugin was ever supported so I am removing it. https://github.com/jazzband/django-tinymce/tree/master/tinymce/static/tinymce/plugins

If you want to include it needs to be included as part of CDN, that's what docs says: `TINYMCE_JS_URL = 'http://debug.example.org/tiny_mce/tiny_mce_src.js'`

This is broken in prod and doesn't effect the functionality, so i am just removing what is not needed