### PR TITLE
issue_656 updated semantic element mapping of UI variant compoent

### DIFF
--- a/frontend/app/theme.ts
+++ b/frontend/app/theme.ts
@@ -27,7 +27,18 @@ const theme = createTheme({
           }
         }
       }
-    }
+    },
+    MuiTypography: {
+      defaultProps: {
+        // https://mui.com/material-ui/react-typography/#changing-the-semantic-element
+        variantMapping: {
+          h3: 'h2',
+          h4: 'h2',
+          h5: 'h2',
+          h6: 'h2',
+        },
+      },
+    },
   }
 });
 


### PR DESCRIPTION
Using the strategy listed in [Material UI Changing the semantic element page](https://mui.com/material-ui/react-typography/#changing-the-semantic-element), added variantMapping for h elements.

To test:

- open Chrome Developer window
- navigate to the "Course Scan ID" and "Start Review" component, and make sure they are rendered as h2 elements in DOM