### PR TITLE
#653, #655: Button a11y improvements - ToggleButton, change focus to solid border

### DIFF
--- a/frontend/app/components/ContentImageCard.tsx
+++ b/frontend/app/components/ContentImageCard.tsx
@@ -43,8 +43,9 @@ const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
         backgroundColor: theme.palette.primary.dark,
       },
     },
-    '&:hover': {
-      backgroundColor: theme.palette.action.hover,
+    '&:focus-visible': {
+      outline: `2px solid ${theme.palette.primary.main}`,
+      outlineOffset: '2px',
     },
   },
 }));

--- a/frontend/app/components/ContentImageCard.tsx
+++ b/frontend/app/components/ContentImageCard.tsx
@@ -44,8 +44,7 @@ const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
       },
     },
     '&:focus-visible': {
-      outline: `2px solid ${theme.palette.primary.main}`,
-      outlineOffset: '2px',
+      boxShadow: `0 0 0 2px ${theme.palette.common.white}, 0 0 0 4px ${theme.palette.primary.main}`,
     },
   },
 }));

--- a/frontend/app/components/ContentImageCard.tsx
+++ b/frontend/app/components/ContentImageCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Card, CardMedia, CardContent, TextField, Box, Typography, styled, Button, Chip, Link, Tooltip } from '@mui/material';
+import { Card, CardMedia, CardContent, TextField, Box, Typography, styled, Chip, Link, Tooltip, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
@@ -14,24 +14,6 @@ const StyledCard = styled(Card)(({ theme }) => ({
   borderColor: theme.palette.divider,
 }));
 
-const ActionButton = styled(Button)<{ selected?: boolean }>(({ theme, selected }) => ({
-  flex: 1,
-  minWidth: 0,
-  padding: theme.spacing(1, 1.5),
-  fontSize: '0.875rem',
-  fontWeight: 500,
-  textTransform: 'none',
-  borderRadius: theme.spacing(0.75),
-  border: '1px solid',
-  borderColor: selected ? theme.palette.primary.main : theme.palette.divider,
-  backgroundColor: selected ? theme.palette.primary.main : 'transparent',
-  color: selected ? theme.palette.primary.contrastText : theme.palette.text.primary,
-  '&:hover': {
-    borderColor: theme.palette.primary.main,
-    backgroundColor: selected ? theme.palette.primary.dark : theme.palette.action.hover,
-  },
-}));
-
 const StatusChip = styled(Chip)(() => ({
   alignSelf: 'flex-start',
   fontWeight: 500,
@@ -42,6 +24,29 @@ const CardHeader = styled(Box)(({ theme }) => ({
   padding: theme.spacing(2),
   paddingBottom: theme.spacing(1),
   borderBottom: `1px solid ${theme.palette.divider}`,
+}));
+
+const StyledToggleButtonGroup = styled(ToggleButtonGroup)(({ theme }) => ({
+  width: '100%',
+  '& .MuiToggleButtonGroup-grouped': {
+    flex: 1,
+    minWidth: 0,
+    padding: theme.spacing(1, 1.5),
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    textTransform: 'none',
+    color: theme.palette.text.primary,
+    '&.Mui-selected': {
+      color: theme.palette.primary.contrastText,
+      backgroundColor: theme.palette.primary.main,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
+    },
+  },
 }));
 
 interface ContentImageCardProps {
@@ -71,6 +76,12 @@ export default function ContentImageCard({
   const handleActionChange = (newAction: ActionType) => {
     if (onActionChange) {
       onActionChange(newAction);
+    }
+  };
+
+  const handleToggleChange = (_event: React.MouseEvent<HTMLElement>, newValue: ActionType | null) => {
+    if (newValue !== null) {
+      handleActionChange(newValue);
     }
   };
 
@@ -154,39 +165,38 @@ export default function ContentImageCard({
             {localAltText.length} characters
           </Typography>
         </Box>
-        <Box sx={{display: 'flex', gap: 1, width: '100%',}}>
-          <ActionButton 
-            selected={action === 'approve'}
-            startIcon={<CheckIcon />}
-            onClick={() => handleActionChange('approve')}
-          >
+        <StyledToggleButtonGroup
+          value={action}
+          exclusive
+          onChange={handleToggleChange}
+          fullWidth
+          size="small"
+          color="primary"
+          aria-label="Image action"
+        >
+          <ToggleButton value="approve" aria-label="Approve">
+            <CheckIcon sx={{ mr: 0.5, fontSize: '1.1rem' }} />
             Approve
-          </ActionButton>
+          </ToggleButton>
           <Tooltip
             title="Skip for now — this image will be resurfaced on the next scan and is not updated."
             placement="top"
           >
-            <ActionButton 
-              selected={action === 'skip'}
-              startIcon={<AccessTimeIcon />}
-              onClick={() => handleActionChange('skip')}
-            >
+            <ToggleButton value="skip" aria-label="Skip">
+              <AccessTimeIcon sx={{ mr: 0.5, fontSize: '1.1rem' }} />
               Skip
-            </ActionButton>
+            </ToggleButton>
           </Tooltip>
           <Tooltip
             title="Decorative images have no alt text and will be ignored by assistive technology."
             placement="top"
           >
-            <ActionButton 
-              selected={action === 'decorative'}
-              startIcon={<VisibilityOffIcon />}
-              onClick={() => handleActionChange('decorative')}
-            >
+            <ToggleButton value="decorative" aria-label="Decorative">
+              <VisibilityOffIcon sx={{ mr: 0.5, fontSize: '1.1rem' }} />
               Decorative
-            </ActionButton>
+            </ToggleButton>
           </Tooltip>
-        </Box>
+        </StyledToggleButtonGroup>
       </CardContent>
     </StyledCard>
   );

--- a/frontend/app/components/HeaderAppBar.tsx
+++ b/frontend/app/components/HeaderAppBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AppBar, Breadcrumbs, Button, Grid, styled, Toolbar, Typography } from '@mui/material';
+import { AppBar, Breadcrumbs, Button, Grid, Toolbar, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import Link from '@mui/material/Link';
 import { User } from '../interfaces';

--- a/frontend/app/components/HeaderAppBar.tsx
+++ b/frontend/app/components/HeaderAppBar.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { AppBar, Breadcrumbs, Button, Grid, Toolbar, Typography } from '@mui/material';
+import { AppBar, Breadcrumbs, Button, Grid, styled, Toolbar, Typography } from '@mui/material';
 import { Link as RouterLink } from 'react-router-dom';
 import Link from '@mui/material/Link';
 import { User } from '../interfaces';
 
+const StyledHeaderButton = styled(Button)({
+  '&:focus-visible': {
+    outline: '2px solid white',
+    outlineOffset: '2px',
+  },
+}) as typeof Button;
 interface HeaderAppBarProps {
   user: User | null;
   helpURL: string;
@@ -49,8 +55,8 @@ export default function HeaderAppBar (props: HeaderAppBarProps) {
           </Grid>
         </Grid>
         <Grid item xs='auto' container justifyContent='space-around'>
-          <Button color='inherit' target='_blank' href={helpURL}>Help</Button>
-          {user?.is_staff && <Button color='inherit' href='/admin'>Admin</Button>}
+          <StyledHeaderButton color='inherit' target='_blank' rel='noopener noreferrer' href={helpURL}>Help</StyledHeaderButton>
+          {user?.is_staff && <StyledHeaderButton color='inherit' href='/admin'>Admin</StyledHeaderButton>}
         </Grid>
       </Toolbar>
     </AppBar>

--- a/frontend/app/components/HeaderAppBar.tsx
+++ b/frontend/app/components/HeaderAppBar.tsx
@@ -4,12 +4,6 @@ import { Link as RouterLink } from 'react-router-dom';
 import Link from '@mui/material/Link';
 import { User } from '../interfaces';
 
-const StyledHeaderButton = styled(Button)({
-  '&:focus-visible': {
-    outline: '2px solid white',
-    outlineOffset: '2px',
-  },
-}) as typeof Button;
 interface HeaderAppBarProps {
   user: User | null;
   helpURL: string;
@@ -55,8 +49,8 @@ export default function HeaderAppBar (props: HeaderAppBarProps) {
           </Grid>
         </Grid>
         <Grid item xs='auto' container justifyContent='space-around'>
-          <StyledHeaderButton color='inherit' target='_blank' rel='noopener noreferrer' href={helpURL}>Help</StyledHeaderButton>
-          {user?.is_staff && <StyledHeaderButton color='inherit' href='/admin'>Admin</StyledHeaderButton>}
+          <Button color='inherit' target='_blank' rel='noopener noreferrer' href={helpURL}>Help</Button>
+          {user?.is_staff && <Button color='inherit' href='/admin'>Admin</Button>}
         </Grid>
       </Toolbar>
     </AppBar>

--- a/frontend/app/theme.ts
+++ b/frontend/app/theme.ts
@@ -29,15 +29,22 @@ const theme = createTheme({
       }
     },
     MuiButton: {
+      defaultProps: {
+        disableFocusRipple: true,
+      },
       styleOverrides: {
         root: ({ theme }) => ({
           '&:focus-visible': {
-            outline: `2px solid ${theme.palette.primary.main}`,
-            outlineOffset: '2px',
-          }
+            boxShadow: `0 0 0 2px ${theme.palette.common.white}, 0 0 0 4px ${theme.palette.primary.main}`,
+          }, 
         })
       }
     },
+    MuiButtonBase: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    }
   }
 });
 

--- a/frontend/app/theme.ts
+++ b/frontend/app/theme.ts
@@ -27,7 +27,17 @@ const theme = createTheme({
           }
         }
       }
-    }
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          '&:focus-visible': {
+            outline: `2px solid ${theme.palette.primary.main}`,
+            outlineOffset: '2px',
+          }
+        })
+      }
+    },
   }
 });
 


### PR DESCRIPTION
Accessibility additions: 
- Use [ToggleButton and ToggleButtonGroup](https://mui.com/material-ui/react-toggle-button/) to include better screen reader visibility for the review action taken.
- Add high-contrast outline to buttons' focus-visible attributes

Respective changes test plans
1. Start a review, make an action selection for an image and check in HTML content if aria-label is set and aria-pressed is accurately set to the proper button in focus. Screen readers should announce the button is "selected".
<img width="510" height="316" alt="Screenshot 2026-04-17 at 11 33 02 AM" src="https://github.com/user-attachments/assets/8912fb31-e28d-4896-bd62-d8358225e0c3" />

2.  check tab focus on all buttons, including header bar. boxShadow shows solid lines, replacing the original hovering focus indicator:
<img width="210" height="67" alt="Screenshot 2026-04-16 at 4 54 14 PM" src="https://github.com/user-attachments/assets/bbcf8af7-84b1-4361-8cff-9b7ebf065e11" />
<img width="210" height="67" alt="Screenshot 2026-04-16 at 4 55 03 PM" src="https://github.com/user-attachments/assets/713c06f1-6f18-4038-8d3f-9760d2c0f5d7" />
