### PR TITLE
#680 Additional Roles support to access the app

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -171,3 +171,11 @@ REDIS_PASS=
 # Example: If USE_CANVAS_TOKEN=false here but toggled to True in admin, token WILL be sent.
 # Example: If USE_CANVAS_TOKEN=true here but toggled to False in admin, token will NOT be sent.
 # USE_CANVAS_TOKEN=false
+
+# Additional Canvas roles to allow access to the tool beyond default base roles.
+# NOTE: Base roles Account Admin, Sub-Account Admin, and TeacherEnrollment are always allowed.
+# This value sets the INITIAL default in the Constance database and can be edited in
+# Django Admin UI -> Constance section at runtime.
+# Leave empty to allow only base roles by default.
+# Supports a single value (no comma) or CSV list.
+# ADDITIONAL_STAFF_COURSE_ROLES=

--- a/.env.sample
+++ b/.env.sample
@@ -173,9 +173,8 @@ REDIS_PASS=
 # USE_CANVAS_TOKEN=false
 
 # Additional Canvas roles to allow access to the tool beyond default base roles.
-# NOTE: Base roles Account Admin, Sub-Account Admin, and TeacherEnrollment are always allowed.
+# NOTE: Base roles Account Admin, TeacherEnrollment are always allowed.
 # This value sets the INITIAL default in the Constance database and can be edited in
 # Django Admin UI -> Constance section at runtime.
-# Leave empty to allow only base roles by default.
 # Supports a single value (no comma) or CSV list.
-# ADDITIONAL_STAFF_COURSE_ROLES=
+# ADDITIONAL_STAFF_COURSE_ROLES='Sub-Account Admin'

--- a/README.md
+++ b/README.md
@@ -111,6 +111,30 @@ All test are in the `tests` folder. To run the tests
 ```sh 
 docker exec -it instructor_tools python manage.py test
 ```
+
+### Configuring Canvas Staff Role Access
+Access to the tool is controlled by Canvas course role values sent in the LTI custom parameter
+`canvas_course_roles`.
+
+The following base roles are always treated as staff:
+1. `Account Admin`
+2. `Sub-Account Admin`
+3. `TeacherEnrollment`
+
+To add institution-specific roles without code changes:
+1. Open Django Admin.
+2. Go to `Constance`.
+3. Edit `ADDITIONAL_STAFF_COURSE_ROLES` with a comma-separated list of exact role strings.
+
+Default additional roles:
+1. none (empty value)
+
+Notes:
+1. Role matching is case-insensitive after trimming whitespace.
+2. You can add or remove entries at runtime from Django Admin.
+3. Environment variable `ADDITIONAL_STAFF_COURSE_ROLES` only provides the initial default value.
+    After a value is saved in Constance, the admin value takes precedence.
+
 ### Django Queue
 1. Getting the Alt text from course images run as a background task.
 2. We are using [Django ORM](https://django-q2.readthedocs.io/en/master/brokers.html#django-orm) is set a default message Broker.

--- a/README.md
+++ b/README.md
@@ -118,16 +118,16 @@ Access to the tool is controlled by Canvas course role values sent in the LTI cu
 
 The following base roles are always treated as staff:
 1. `Account Admin`
-2. `Sub-Account Admin`
 3. `TeacherEnrollment`
 
 To add institution-specific roles without code changes:
 1. Open Django Admin.
 2. Go to `Constance`.
-3. Edit `ADDITIONAL_STAFF_COURSE_ROLES` with a comma-separated list of exact role strings.
+3. Edit `ADDITIONAL_STAFF_COURSE_ROLES` with a comma-separated list of exact role strings. 
 
 Default additional roles:
-1. none (empty value)
+1. `Sub-Account Admin`
+
 
 Notes:
 1. Role matching is case-insensitive after trimming whitespace.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Access to the tool is controlled by Canvas course role values sent in the LTI cu
 
 The following base roles are always treated as staff:
 1. `Account Admin`
-3. `TeacherEnrollment`
+2. `TeacherEnrollment`
 
 To add institution-specific roles without code changes:
 1. Open Django Admin.

--- a/backend/canvas_app_explorer/canvas_roles.py
+++ b/backend/canvas_app_explorer/canvas_roles.py
@@ -1,5 +1,7 @@
 from enum import Enum
 
+from constance import config
+
 
 class CanvasRole(Enum):
     ACCOUNT_ADMIN = 'Account Admin'
@@ -8,3 +10,46 @@ class CanvasRole(Enum):
 
 
 STAFF_COURSE_ROLES = [CanvasRole.ACCOUNT_ADMIN, CanvasRole.SUB_ACCOUNT_ADMIN, CanvasRole.TEACHER]
+
+
+def normalize_role_value(role_value: str) -> str:
+    return role_value.strip().lower()
+
+
+def get_default_staff_course_role_values() -> list[str]:
+    return [normalize_role_value(role.value) for role in STAFF_COURSE_ROLES]
+
+
+def _parse_configured_roles(configured_roles: object) -> list[str]:
+    if configured_roles is None:
+        return []
+
+    if isinstance(configured_roles, str):
+        candidate_roles = configured_roles.split(',')
+    elif isinstance(configured_roles, (list, tuple, set)):
+        candidate_roles = list(configured_roles)
+    else:
+        candidate_roles = [str(configured_roles)]
+
+    parsed_roles = [normalize_role_value(str(role)) for role in candidate_roles]
+    parsed_roles = [role for role in parsed_roles if role]
+
+    # Preserve order while removing duplicates in configured values.
+    return list(dict.fromkeys(parsed_roles))
+
+
+def get_additional_staff_course_role_values() -> list[str]:
+    configured_roles = getattr(config, 'ADDITIONAL_STAFF_COURSE_ROLES', '')
+    return _parse_configured_roles(configured_roles)
+
+
+def get_effective_staff_course_role_values() -> list[str]:
+    default_roles = get_default_staff_course_role_values()
+    additional_roles = get_additional_staff_course_role_values()
+
+    effective_roles = list(default_roles)
+    for role in additional_roles:
+        if role not in effective_roles:
+            effective_roles.append(role)
+
+    return effective_roles

--- a/backend/canvas_app_explorer/canvas_roles.py
+++ b/backend/canvas_app_explorer/canvas_roles.py
@@ -1,15 +1,13 @@
 from enum import Enum
-
 from constance import config
 
 
 class CanvasRole(Enum):
     ACCOUNT_ADMIN = 'Account Admin'
-    SUB_ACCOUNT_ADMIN = 'Sub-Account Admin'
     TEACHER = 'TeacherEnrollment'
 
 
-STAFF_COURSE_ROLES = [CanvasRole.ACCOUNT_ADMIN, CanvasRole.SUB_ACCOUNT_ADMIN, CanvasRole.TEACHER]
+STAFF_COURSE_ROLES = [CanvasRole.ACCOUNT_ADMIN, CanvasRole.TEACHER]
 
 
 def normalize_role_value(role_value: str) -> str:
@@ -39,7 +37,7 @@ def _parse_configured_roles(configured_roles: object) -> list[str]:
 
 
 def get_additional_staff_course_role_values() -> list[str]:
-    configured_roles = getattr(config, 'ADDITIONAL_STAFF_COURSE_ROLES', '')
+    configured_roles = config.ADDITIONAL_STAFF_COURSE_ROLES
     return _parse_configured_roles(configured_roles)
 
 

--- a/backend/canvas_app_explorer/canvas_roles.py
+++ b/backend/canvas_app_explorer/canvas_roles.py
@@ -31,11 +31,11 @@ def _parse_configured_roles(configured_roles: object) -> list[str]:
     else:
         candidate_roles = [str(configured_roles)]
 
-    parsed_roles = [normalize_role_value(str(role)) for role in candidate_roles]
-    parsed_roles = [role for role in parsed_roles if role]
+    # Normalize roles and filter out empty strings that result from whitespace-only values.
+    non_empty_roles = list(filter(None, (normalize_role_value(str(role)) for role in candidate_roles)))
 
-    # Preserve order while removing duplicates in configured values.
-    return list(dict.fromkeys(parsed_roles))
+    # Remove duplicates from configured values.
+    return list(set(non_empty_roles))
 
 
 def get_additional_staff_course_role_values() -> list[str]:
@@ -47,9 +47,5 @@ def get_effective_staff_course_role_values() -> list[str]:
     default_roles = get_default_staff_course_role_values()
     additional_roles = get_additional_staff_course_role_values()
 
-    effective_roles = list(default_roles)
-    for role in additional_roles:
-        if role not in effective_roles:
-            effective_roles.append(role)
-
-    return effective_roles
+    # Keep default roles first, then append new configured roles without duplicates.
+    return list(dict.fromkeys(default_roles + additional_roles))

--- a/backend/canvas_app_explorer/lti1p3.py
+++ b/backend/canvas_app_explorer/lti1p3.py
@@ -174,7 +174,7 @@ def create_user_in_django(request: HttpRequest, launch_data: Dict[str, Any]):
 
     if not user_is_course_staff:
         logger.warning(f'User {username} does not have a staff role.')
-        error_message = 'You must be an instructor in this course or an administrator to access this tool.'
+        error_message = 'You must have an approved role to access this tool. Please contact support.'
         raise PermissionDenied(error_message)
 
     email = launch_data['email']

--- a/backend/canvas_app_explorer/lti1p3.py
+++ b/backend/canvas_app_explorer/lti1p3.py
@@ -10,6 +10,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
+from constance import config
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from pylti1p3.contrib.django import (
@@ -174,7 +175,7 @@ def create_user_in_django(request: HttpRequest, launch_data: Dict[str, Any]):
 
     if not user_is_course_staff:
         logger.warning(f'User {username} does not have a staff role.')
-        error_message = 'You must have an approved role to access this tool. Please contact support.'
+        error_message = 'You must have an approved role to access this tool. Please contact your campus Canvas support.'
         raise PermissionDenied(error_message)
 
     email = launch_data['email']

--- a/backend/canvas_app_explorer/lti1p3.py
+++ b/backend/canvas_app_explorer/lti1p3.py
@@ -17,7 +17,7 @@ from pylti1p3.contrib.django import (
 )
 from pylti1p3.exception import LtiException
 
-from .canvas_roles import STAFF_COURSE_ROLES
+from .canvas_roles import get_effective_staff_course_role_values
 
 
 logger = logging.getLogger(__name__)
@@ -157,14 +157,18 @@ def create_user_in_django(request: HttpRequest, launch_data: Dict[str, Any]):
     term_name = custom_params[COURSE_TERM_NAME_KEY] if COURSE_TERM_NAME_KEY in custom_params else None
     account_id = custom_params[COURSE_ACCOUNT_ID_KEY] if COURSE_ACCOUNT_ID_KEY in custom_params else None
     account_name = custom_params[COURSE_ACCOUNT_NAME_KEY] if COURSE_ACCOUNT_NAME_KEY in custom_params else None
-    course_roles = custom_params[COURSE_ROLES_KEY].split(',')
+    course_roles = [
+        course_role.strip().lower()
+        for course_role in custom_params[COURSE_ROLES_KEY].split(',')
+        if course_role.strip()
+    ]
 
     if 'email' not in launch_data.keys():
         logger.warning('An instructor/admin likely launched the tool using Student View (Test Student).')
         error_message = 'Student View is not available for Canvas App Explorer.'
         raise PermissionDenied(error_message)
 
-    staff_course_role_values = [role.value for role in STAFF_COURSE_ROLES]
+    staff_course_role_values = get_effective_staff_course_role_values()
     user_staff_course_roles = [course_role for course_role in course_roles if course_role in staff_course_role_values]
     user_is_course_staff = len(user_staff_course_roles) > 0
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -467,6 +467,15 @@ option with no further explanation.""").strip(),
     'USE_CANVAS_TOKEN': (
         os.getenv('USE_CANVAS_TOKEN', 'false').lower() in ('true', '1', 't'),
         'Whether to use Canvas authentication token when fetching images from Canvas'
+    ),
+    'ADDITIONAL_STAFF_COURSE_ROLES': (
+        os.getenv(
+            'ADDITIONAL_STAFF_COURSE_ROLES',
+            ''
+        ),
+        'Additional Canvas course roles that should be treated as staff access. '
+        'Comma-separated values. Base roles Account Admin, Sub-Account Admin, and '
+        'TeacherEnrollment are always allowed.'
     )
 }
 # Use in-memory backend for constance during tests to avoid database migration issues

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -469,13 +469,9 @@ option with no further explanation.""").strip(),
         'Whether to use Canvas authentication token when fetching images from Canvas'
     ),
     'ADDITIONAL_STAFF_COURSE_ROLES': (
-        os.getenv(
-            'ADDITIONAL_STAFF_COURSE_ROLES',
-            ''
-        ),
-        'Additional Canvas course roles that should be treated as staff access. '
-        'Comma-separated values. Base roles Account Admin, Sub-Account Admin, and '
-        'TeacherEnrollment are always allowed.'
+        os.getenv('ADDITIONAL_STAFF_COURSE_ROLES','Sub-Account Admin'),
+        'Additional Canvas roles that gives access to the tool beyond default base roles (Account Admin, TeacherEnrollment). '
+        'Supports a single value (no comma) or CSV list.'
     )
 }
 # Use in-memory backend for constance during tests to avoid database migration issues

--- a/backend/tests/test_canvas_roles_configurable_access.py
+++ b/backend/tests/test_canvas_roles_configurable_access.py
@@ -1,0 +1,141 @@
+from unittest.mock import patch
+
+from django.core.exceptions import PermissionDenied
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory, TestCase
+
+from backend.canvas_app_explorer.canvas_roles import (
+    get_additional_staff_course_role_values,
+    get_default_staff_course_role_values,
+    get_effective_staff_course_role_values,
+)
+from backend.canvas_app_explorer.lti1p3 import create_user_in_django
+
+
+class TestCanvasRoleResolution(TestCase):
+    def test_effective_roles_always_include_default_roles(self):
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = ''
+
+            effective_roles = get_effective_staff_course_role_values()
+            default_roles = get_default_staff_course_role_values()
+
+            for role in default_roles:
+                self.assertIn(role, effective_roles)
+
+            self.assertIn('account admin', effective_roles)
+            self.assertIn('sub-account admin', effective_roles)
+            self.assertIn('teacherenrollment', effective_roles)
+
+    def test_additional_roles_are_trimmed_and_deduplicated(self):
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = (
+                ' Junior Admin ,Instructional Designer,Junior Admin, Root privileges for any Admin '
+            )
+
+            additional_roles = get_additional_staff_course_role_values()
+
+            self.assertEqual(
+                additional_roles,
+                ['junior admin', 'instructional designer', 'root privileges for any admin'],
+            )
+
+    def test_additional_roles_support_single_value_and_none(self):
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Junior Admin'
+            self.assertEqual(get_additional_staff_course_role_values(), ['junior admin'])
+
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = None
+            self.assertEqual(get_additional_staff_course_role_values(), [])
+
+    def test_effective_roles_merge_default_and_additional(self):
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Junior Admin,Instructional Designer'
+
+            effective_roles = get_effective_staff_course_role_values()
+
+            self.assertIn('account admin', effective_roles)
+            self.assertIn('sub-account admin', effective_roles)
+            self.assertIn('teacherenrollment', effective_roles)
+            self.assertIn('junior admin', effective_roles)
+            self.assertIn('instructional designer', effective_roles)
+
+
+class TestLtiRoleAuthorizationWithConfigurableRoles(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _request_with_session(self):
+        request = self.factory.post('/launch')
+        middleware = SessionMiddleware(lambda req: None)
+        middleware.process_request(request)
+        request.session.save()
+        return request
+
+    def _launch_data(self, username: str, course_roles: str):
+        return {
+            'https://purl.imsglobal.org/spec/lti/claim/custom': {
+                'user_username': username,
+                'canvas_course_id': '123',
+                'canvas_course_roles': course_roles,
+            },
+            'https://purl.imsglobal.org/spec/lti/claim/context': {'title': 'Test Course'},
+            'https://purl.imsglobal.org/spec/lti/claim/roles': [],
+            'https://purl.imsglobal.org/spec/lti/claim/lis': {'person_sourcedid': f'sis-{username}'},
+            'email': f'{username}@example.edu',
+            'given_name': 'Test',
+            'family_name': 'User',
+            'name': 'Test User',
+        }
+
+    def test_default_teacher_role_still_authorized(self):
+        request = self._request_with_session()
+        launch_data = self._launch_data('teacher-user', 'TEACHERENROLLMENT')
+
+        with patch(
+            'backend.canvas_app_explorer.lti1p3.get_effective_staff_course_role_values',
+            return_value=['account admin', 'sub-account admin', 'teacherenrollment'],
+        ):
+            create_user_in_django(request, launch_data)
+
+        self.assertEqual(request.session['course_id'], 123)
+
+    def test_junior_admin_can_be_authorized_via_configured_roles(self):
+        request = self._request_with_session()
+        launch_data = self._launch_data('junior-admin-user', 'JUNIOR ADMIN')
+
+        with patch(
+            'backend.canvas_app_explorer.lti1p3.get_effective_staff_course_role_values',
+            return_value=['account admin', 'sub-account admin', 'teacherenrollment', 'junior admin'],
+        ):
+            create_user_in_django(request, launch_data)
+
+        self.assertEqual(request.session['course_id'], 123)
+
+    def test_root_privileges_role_can_be_authorized_via_configured_roles(self):
+        request = self._request_with_session()
+        launch_data = self._launch_data('root-admin-user', 'ROOT PRIVILEGES FOR ANY ADMIN')
+
+        with patch(
+            'backend.canvas_app_explorer.lti1p3.get_effective_staff_course_role_values',
+            return_value=[
+                'account admin',
+                'sub-account admin',
+                'teacherenrollment',
+                'root privileges for any admin',
+            ],
+        ):
+            create_user_in_django(request, launch_data)
+
+        self.assertEqual(request.session['course_id'], 123)
+
+    def test_unconfigured_non_staff_role_is_denied(self):
+        request = self._request_with_session()
+        launch_data = self._launch_data('non-staff-user', 'Junior Admin')
+
+        with patch(
+            'backend.canvas_app_explorer.lti1p3.get_effective_staff_course_role_values',
+            return_value=['account admin', 'sub-account admin', 'teacherenrollment'],
+        ):
+            with self.assertRaises(PermissionDenied):
+                create_user_in_django(request, launch_data)

--- a/backend/tests/test_canvas_roles_configurable_access.py
+++ b/backend/tests/test_canvas_roles_configurable_access.py
@@ -14,8 +14,9 @@ from backend.canvas_app_explorer.lti1p3 import create_user_in_django
 
 class TestCanvasRoleResolution(TestCase):
     def test_effective_roles_always_include_default_roles(self):
+        # Simulate the constance default value for ADDITIONAL_STAFF_COURSE_ROLES ('Sub-Account Admin').
         with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
-            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = ''
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Sub-Account Admin'
 
             effective_roles = get_effective_staff_course_role_values()
             default_roles = get_default_staff_course_role_values()
@@ -24,8 +25,8 @@ class TestCanvasRoleResolution(TestCase):
                 self.assertIn(role, effective_roles)
 
             self.assertIn('account admin', effective_roles)
-            self.assertIn('sub-account admin', effective_roles)
             self.assertIn('teacherenrollment', effective_roles)
+            self.assertIn('sub-account admin', effective_roles)
 
     def test_additional_roles_are_trimmed_and_deduplicated(self):
         with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
@@ -48,15 +49,23 @@ class TestCanvasRoleResolution(TestCase):
             mock_config.ADDITIONAL_STAFF_COURSE_ROLES = None
             self.assertEqual(get_additional_staff_course_role_values(), [])
 
+    def test_subaccount_admin_is_default_additional_role(self):
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Sub-Account Admin'
+
+            additional_roles = get_additional_staff_course_role_values()
+
+            self.assertIn('sub-account admin', additional_roles)
+
     def test_effective_roles_merge_default_and_additional(self):
         with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
-            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Junior Admin,Instructional Designer'
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Sub-Account Admin,Junior Admin,Instructional Designer'
 
             effective_roles = get_effective_staff_course_role_values()
 
             self.assertIn('account admin', effective_roles)
-            self.assertIn('sub-account admin', effective_roles)
             self.assertIn('teacherenrollment', effective_roles)
+            self.assertIn('sub-account admin', effective_roles)
             self.assertIn('junior admin', effective_roles)
             self.assertIn('instructional designer', effective_roles)
 
@@ -137,5 +146,28 @@ class TestLtiRoleAuthorizationWithConfigurableRoles(TestCase):
             'backend.canvas_app_explorer.lti1p3.get_effective_staff_course_role_values',
             return_value=['account admin', 'sub-account admin', 'teacherenrollment'],
         ):
+            with self.assertRaises(PermissionDenied):
+                create_user_in_django(request, launch_data)
+
+    def test_subaccount_admin_authorized_with_default_constance_config(self):
+        # Verify that a Sub-Account Admin can launch when ADDITIONAL_STAFF_COURSE_ROLES
+        # is set to the constance default ('Sub-Account Admin') and no env var override is present.
+        request = self._request_with_session()
+        launch_data = self._launch_data('subaccount-admin-user', 'Sub-Account Admin')
+
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = 'Sub-Account Admin'
+            create_user_in_django(request, launch_data)
+
+        self.assertEqual(request.session['course_id'], 123)
+
+    def test_subaccount_admin_denied_when_default_is_cleared(self):
+        # Verify that a Sub-Account Admin is denied when ADDITIONAL_STAFF_COURSE_ROLES
+        # is explicitly cleared (no roles configured).
+        request = self._request_with_session()
+        launch_data = self._launch_data('subaccount-admin-user', 'Sub-Account Admin')
+
+        with patch('backend.canvas_app_explorer.canvas_roles.config') as mock_config:
+            mock_config.ADDITIONAL_STAFF_COURSE_ROLES = ''
             with self.assertRaises(PermissionDenied):
                 create_user_in_django(request, launch_data)

--- a/backend/tests/test_canvas_roles_configurable_access.py
+++ b/backend/tests/test_canvas_roles_configurable_access.py
@@ -36,8 +36,8 @@ class TestCanvasRoleResolution(TestCase):
             additional_roles = get_additional_staff_course_role_values()
 
             self.assertEqual(
-                additional_roles,
-                ['junior admin', 'instructional designer', 'root privileges for any admin'],
+                set(additional_roles),
+                {'junior admin', 'instructional designer', 'root privileges for any admin'},
             )
 
     def test_additional_roles_support_single_value_and_none(self):


### PR DESCRIPTION
Fixes #680 

This Default Role are authorized to access the tool: 'TeacherEnrollment','Account Admin'.
Additional roles can be configured via Admin Console. 

Unauthorized users will conti to see this error if there role doesn't fit in the list `Permission denied. You must be an instructor in this course or an administrator to access this tool.`