### PR TITLE
#691 Mysql support for SSL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -75,6 +75,13 @@ ALLOWED_HOSTS=.ngrok.io,.localhost,127.0.0.1
 # Database Password
 # DB_PASSWORD=cae_pw
 
+# MySQL SSL mode (DISABLED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY)
+# Default in settings.py is REQUIRED
+# DB_SSL_MODE=REQUIRED
+
+# Optional CA certificate path for MySQL TLS verification
+# DB_SSL_CA=/path/to/ca-certificate.pem
+
 ##### Redis
 
 # Redis Password, default is blank

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -117,9 +117,10 @@ def _get_db_options():
     """
     options = {'charset': 'utf8mb4'}
     options['ssl_mode'] = os.getenv('DB_SSL_MODE', 'REQUIRED')
-    
+
     ca_cert = os.getenv('DB_SSL_CA')
-    ca_cert and options.update({'ssl_ca': ca_cert})
+    if ca_cert:
+        options['ssl'] = {'ca': ca_cert}
     
     return options
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -112,7 +112,7 @@ def _get_db_options():
     Build database OPTIONS dict with conditional SSL support.
     
     SSL Configuration:
-    - DB_SSL_MODE: Set to 'REQUIRED', 'VERIFY_IDENTITY', 'VERIFY_CA', or 'DISABLED' (default: 'REQUIRED')
+    - DB_SSL_MODE: Values include 'REQUIRED', 'VERIFY_IDENTITY', 'VERIFY_CA', 'DISABLED', 'PREFERRED'
     - DB_SSL_CA: Path to CA certificate (optional, used for verification)
     """
     options = {'charset': 'utf8mb4'}

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -116,10 +116,10 @@ def _get_db_options():
     - DB_SSL_CA: Path to CA certificate (optional, used for verification)
     """
     options = {'charset': 'utf8mb4'}
-    options['ssl_mode'] = os.getenv('DB_SSL_MODE', 'REQUIRED')
 
     ca_cert = os.getenv('DB_SSL_CA')
     if ca_cert:
+        options['ssl_mode'] = os.getenv('DB_SSL_MODE', 'VERIFY_CA')
         options['ssl'] = {'ca': ca_cert}
     
     return options

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -106,6 +106,23 @@ WSGI_APPLICATION = 'backend.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
+# Helper function to build database OPTIONS with optional SSL support
+def _get_db_options():
+    """
+    Build database OPTIONS dict with conditional SSL support.
+    
+    SSL Configuration:
+    - DB_SSL_MODE: Set to 'REQUIRED', 'VERIFY_IDENTITY', 'VERIFY_CA', or 'DISABLED' (default: 'REQUIRED')
+    - DB_SSL_CA: Path to CA certificate (optional, used for verification)
+    """
+    options = {'charset': 'utf8mb4'}
+    options['ssl_mode'] = os.getenv('DB_SSL_MODE', 'REQUIRED')
+    
+    ca_cert = os.getenv('DB_SSL_CA')
+    ca_cert and options.update({'ssl_ca': ca_cert})
+    
+    return options
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
@@ -114,7 +131,7 @@ DATABASES = {
         'PASSWORD': os.getenv('DB_PASSWORD', 'cae_pw'),
         'HOST': os.getenv('DB_HOST', 'instructor_tools_mysql'),
         'PORT': os.getenv('DB_PORT', '3306'),
-        'OPTIONS': {'charset': 'utf8mb4'},
+        'OPTIONS': _get_db_options(),
         'TEST': {
             'NAME': 'test_it',
             'CHARSET': 'utf8mb4',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: mysql:8-oracle
+    image: mysql:8.4-oracle
     restart: unless-stopped
     command: ['--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci', '--socket=/tmp/mysql.sock']
     environment:


### PR DESCRIPTION
Fixes #691 

Local Optionally support 'DB_SSL_MODE' and DB_SSL_CA, Both values are optional in .env

To Test: If configuration is working
1.  In `Setting.py` Set `os.getenv('DB_SSL_MODE', 'REQUIRED') --->  os.getenv('DB_SSL_MODE', 'SOMETHING_RANDOME')` something random string and do a `docker compose up`, this will throw an error, strong indication that, wiring is working
2.  In `Setting.py` Set `os.getenv('DB_SSL_MODE', 'VERIFY_CA')`, but you did not provide any SSL CA file (.pem file) then it will throw an error, this is to check saying our connection is working as planned

Smoke Test: By default app launch files and DB inserts are happeing
