### PR TITLE
#691 ssl_mode required is default

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -119,7 +119,7 @@ def _get_db_options():
 
     ca_cert = os.getenv('DB_SSL_CA')
     if ca_cert:
-        options['ssl_mode'] = os.getenv('DB_SSL_MODE', 'VERIFY_CA')
+        options['ssl_mode'] = os.getenv('DB_SSL_MODE', 'REQUIRED')
         options['ssl'] = {'ca': ca_cert}
     
     return options


### PR DESCRIPTION
Fixes #691 

Make the REQUIRED as default since we only have CA cert and VERIFY_* mode won't work with it